### PR TITLE
Release v1.0.0

### DIFF
--- a/.github/actions/clean-up-from-tests/action.yaml
+++ b/.github/actions/clean-up-from-tests/action.yaml
@@ -1,0 +1,19 @@
+name: 'Clean up from tests'
+description: 'Delete any existing data created by the tests'
+inputs:
+  github-token:
+    description: "Github token to use when calling GitHub API"
+    default: ""
+runs:
+  using: "composite"
+  steps:
+    - run: |
+        export GITHUB_TOKEN=${{ inputs.github-token }}
+        expected_name="vT.E.S.T"
+        release=$(gh release list | grep $expected_name | cut -f1)
+
+        gh release delete $release
+        git push origin :refs/heads/develop
+        git push origin :refs/heads/release/test
+        git push origin :refs/tags/vT.E.S.T
+      shell: bash

--- a/.github/actions/clean-up-from-tests/action.yaml
+++ b/.github/actions/clean-up-from-tests/action.yaml
@@ -13,9 +13,6 @@ runs:
         expected_name="vT.E.S.T"
         release=$(gh release list | grep $expected_name | cut -f1)
         [ $release ] & gh release delete $release
-        git push origin :refs/heads/develop
-        git push origin :refs/heads/release/test
-        git push origin :refs/tags/vT.E.S.T
       env: 
         GITHUB_TOKEN: ${{ inputs.github-token }}
       shell: bash

--- a/.github/actions/clean-up-from-tests/action.yaml
+++ b/.github/actions/clean-up-from-tests/action.yaml
@@ -10,12 +10,12 @@ runs:
     - name: Delete Release
       run: |
         gh auth status
-        gh release list
-        name="vT.E.S.T"
-        release=$(gh release list | grep $name)
-        echo "Release: $release"
-        [ $release ] && gh release delete "$name" --yes || echo "No release to delete"
-        exit 0
+        # gh release list
+        # name="vT.E.S.T"
+        # release=$(gh release list | grep $name)
+        # echo "Release: $release"
+        # [ $release ] && gh release delete "$name" --yes || echo "No release to delete"
+        # exit 0
       env: 
         GITHUB_TOKEN: ${{ inputs.github-token }}
       shell: bash

--- a/.github/actions/clean-up-from-tests/action.yaml
+++ b/.github/actions/clean-up-from-tests/action.yaml
@@ -15,10 +15,11 @@ runs:
         echo "List releases:"
         gh release list
         echo "That's all of them"
-        # release=$(gh release list | grep $name)
-        # echo "Release: $release"
-        # [ $release ] && gh release delete "$name" --yes || echo "No release to delete"
-        # exit 0
+        all_releases=$(gh release list)
+        [ -z "$all_releases" ] && echo "No releases exist" && exit 0
+        release=$(echo $all_releases | grep $name)
+        [ -z "$release" ] && echo "No release named $name exists in $all_releases" && exit 0
+        gh release delete "$name" --yes
       env: 
         GITHUB_TOKEN: ${{ inputs.github-token }}
       shell: bash

--- a/.github/actions/clean-up-from-tests/action.yaml
+++ b/.github/actions/clean-up-from-tests/action.yaml
@@ -7,12 +7,21 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - run: |
-        export GITHUB_TOKEN=${{ inputs.github-token }}
+
+    - name: Delete Release
+      run: |
         expected_name="vT.E.S.T"
         release=$(gh release list | grep $expected_name | cut -f1)
+        [ $release ] & gh release delete $release
+        git push origin :refs/heads/develop
+        git push origin :refs/heads/release/test
+        git push origin :refs/tags/vT.E.S.T
+      env: 
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+      shell: bash
 
-        gh release delete $release
+    - name: Delete tags / branches
+      run: |
         git push origin :refs/heads/develop
         git push origin :refs/heads/release/test
         git push origin :refs/tags/vT.E.S.T

--- a/.github/actions/clean-up-from-tests/action.yaml
+++ b/.github/actions/clean-up-from-tests/action.yaml
@@ -11,9 +11,8 @@ runs:
     - name: Delete Release
       run: |
         name="vT.E.S.T"
-        release=$(gh release list | grep $name | cut -f1)
-        [ $release ] && gh release delete $release --yes
-        exit 0
+        release=$(gh release list | grep $name)
+        [ $release ] && gh release delete "$name" --yes || exit 0
       env: 
         GITHUB_TOKEN: ${{ inputs.github-token }}
       shell: bash

--- a/.github/actions/clean-up-from-tests/action.yaml
+++ b/.github/actions/clean-up-from-tests/action.yaml
@@ -10,8 +10,9 @@ runs:
     - name: Delete Release
       run: |
         gh auth status
+        name="vT.E.S.T"
+        echo "Release to delete: $name"
         # gh release list
-        # name="vT.E.S.T"
         # release=$(gh release list | grep $name)
         # echo "Release: $release"
         # [ $release ] && gh release delete "$name" --yes || echo "No release to delete"

--- a/.github/actions/clean-up-from-tests/action.yaml
+++ b/.github/actions/clean-up-from-tests/action.yaml
@@ -22,4 +22,5 @@ runs:
         git push origin :refs/heads/develop
         git push origin :refs/heads/release/test
         git push origin :refs/tags/vT.E.S.T
+        exit 0
       shell: bash

--- a/.github/actions/clean-up-from-tests/action.yaml
+++ b/.github/actions/clean-up-from-tests/action.yaml
@@ -10,10 +10,12 @@ runs:
     - name: Delete Release
       run: |
         gh auth status
+        gh release list
         name="vT.E.S.T"
         release=$(gh release list | grep $name)
-        echo $release
+        echo "Release: $release"
         [ $release ] && gh release delete "$name" --yes || echo "No release to delete"
+        exit 0
       env: 
         GITHUB_TOKEN: ${{ inputs.github-token }}
       shell: bash

--- a/.github/actions/clean-up-from-tests/action.yaml
+++ b/.github/actions/clean-up-from-tests/action.yaml
@@ -12,6 +12,7 @@ runs:
       run: |
         name="vT.E.S.T"
         release=$(gh release list | grep $name)
+        echo $release
         [ $release ] && gh release delete "$name" --yes || exit 0
       env: 
         GITHUB_TOKEN: ${{ inputs.github-token }}

--- a/.github/actions/clean-up-from-tests/action.yaml
+++ b/.github/actions/clean-up-from-tests/action.yaml
@@ -12,7 +12,7 @@ runs:
       run: |
         name="vT.E.S.T"
         release=$(gh release list | grep $name | cut -f1)
-        [ $release ] && gh release delete $release
+        [ $release ] && gh release delete $release --yes
         exit 0
       env: 
         GITHUB_TOKEN: ${{ inputs.github-token }}

--- a/.github/actions/clean-up-from-tests/action.yaml
+++ b/.github/actions/clean-up-from-tests/action.yaml
@@ -10,9 +10,10 @@ runs:
 
     - name: Delete Release
       run: |
-        expected_name="vT.E.S.T"
-        release=$(gh release list | grep $expected_name | cut -f1)
-        [ $release ] & gh release delete $release
+        name="vT.E.S.T"
+        release=$(gh release list | grep $name | cut -f1)
+        [ $release ] && gh release delete $release
+        exit 0
       env: 
         GITHUB_TOKEN: ${{ inputs.github-token }}
       shell: bash

--- a/.github/actions/clean-up-from-tests/action.yaml
+++ b/.github/actions/clean-up-from-tests/action.yaml
@@ -12,7 +12,9 @@ runs:
         gh auth status
         name="vT.E.S.T"
         echo "Release to delete: $name"
-        # gh release list
+        echo "List releases:"
+        gh release list
+        echo "That's all of them"
         # release=$(gh release list | grep $name)
         # echo "Release: $release"
         # [ $release ] && gh release delete "$name" --yes || echo "No release to delete"

--- a/.github/actions/clean-up-from-tests/action.yaml
+++ b/.github/actions/clean-up-from-tests/action.yaml
@@ -7,13 +7,13 @@ inputs:
 runs:
   using: "composite"
   steps:
-
     - name: Delete Release
       run: |
+        gh auth status
         name="vT.E.S.T"
         release=$(gh release list | grep $name)
         echo $release
-        [ $release ] && gh release delete "$name" --yes || exit 0
+        [ $release ] && gh release delete "$name" --yes || echo "No release to delete"
       env: 
         GITHUB_TOKEN: ${{ inputs.github-token }}
       shell: bash

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -21,6 +21,8 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - uses: cucumber-actions/versions@v1.0.0
         id: versions
       - uses: cucumber-actions/create-release-pr@v1.1.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,5 @@
+name: Test
+
 on: [push]
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,13 +44,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Assert release exists
-          release=$(gh release list | grep vtest | cut -f1)
-          [ "$release" ]
+          expected_name="vT.E.S.T"
+          release=$(gh release list | grep $expected_name | cut -f1)
+          [ "$release" ] || echo "No release created named $expected_name" && exit 1
 
           # Assert tag points to the head of `develop` branch
           expected=$(git rev-parse develop)
           actual=$(git rev-parse vT.E.S.T)
-          [ "$expected" = "$actual" ]
+          [ "$expected" = "$actual" ] || echo "Commit $expected not tagged as expected" && exit 1
 
           # Clean up
           gh release delete $release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,8 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Assert result
+        env: 
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           release=$(gh release list | grep v1.0.0)
           [ "$release" ]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,7 @@ jobs:
           [ "$release" ] || (echo "No release created named $expected_name" && exit 1)
 
           # Assert that a tag for the release points to the head of `develop` branch
+          git fetch --tags
           expected=$(git rev-parse develop)
           actual=$(git rev-parse vT.E.S.T)
           [ "$expected" = "$actual" ] || (echo "Commit $expected not tagged as expected" && exit 1)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
           git commit -am "Release v1.0.0"
       - name: Create release branch
         run: |
-          git checkout head^
+          git checkout HEAD^
           git checkout -b release/test/v1.0.0
           git merge develop
           git push --force

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
           git checkout HEAD^
           git checkout -b release/test/v1.0.0
           git merge develop
-          git push --set-upstream origin release/test/v1.0.0
+          git push --force --set-upstream origin release/test/v1.0.0
       - name: Attempt to create Release
         uses: ./
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,12 +46,12 @@ jobs:
           # Assert release exists
           expected_name="vT.E.S.T"
           release=$(gh release list | grep $expected_name | cut -f1)
-          [ "$release" ] || echo "No release created named $expected_name" && exit 1
+          [ "$release" ] || (echo "No release created named $expected_name" && exit 1)
 
           # Assert tag points to the head of `develop` branch
           expected=$(git rev-parse develop)
           actual=$(git rev-parse vT.E.S.T)
-          [ "$expected" = "$actual" ] || echo "Commit $expected not tagged as expected" && exit 1
+          [ "$expected" = "$actual" ] || (echo "Commit $expected not tagged as expected" && exit 1)
 
           # Clean up
           gh release delete $release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - uses: ./.github/actions/clean-up-from-tests
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up git config
         run: |
           git config --global user.email "github-actions@example.com"
@@ -54,9 +57,6 @@ jobs:
           expected=$(git rev-parse develop)
           actual=$(git rev-parse vT.E.S.T)
           [ "$expected" = "$actual" ] || (echo "Commit $expected not tagged as expected" && exit 1)
-
-          # Clean up
-          gh release delete $release
-          git push origin :refs/heads/develop
-          git push origin :refs/heads/release/test
-          git push origin :refs/tags/vT.E.S.T
+      - uses: ./.github/actions/clean-up-from-tests
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
           git checkout HEAD^
           git checkout -b release/test/v1.0.0
           git merge develop
-          git push --force
+          git push --set-upstream origin release/test/v1.0.0
       - name: Attempt to create Release
         uses: ./
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,8 @@ jobs:
           git checkout HEAD^
           git checkout -b release/test
           git merge --ff-only develop 
-          git push --set-upstream origin release/test
+          # use `--force` just in case previous cleanup didn't run
+          git push --force --set-upstream origin release/test
       - name: Attempt to create Release
         uses: ./
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,11 +39,11 @@ jobs:
         uses: ./
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Assert result
+      - name: Assert release exists
         env: 
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          release=$(gh release list | grep v1.0.0)
+          release=$(gh release list | grep v1.0.0 | cut -f1)
           [ "$release" ]
           gh release delete $release
           git push origin :refs/heads/release/test/v1.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on: [push]
 jobs:
   test:
     runs-on: ubuntu-latest
-    name: Creates a Release for a squashed release branch
+    name: Creates a Release for a fast-forwarded release branch
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -15,34 +15,33 @@ jobs:
           git config --global user.name "GitHub Actions"
           git checkout --orphan develop
       - run: touch CHANGELOG.md
-      - name: Create a simple changelog file
+      - name: Create a simple CHANGELOG
         uses: cucumber-actions/changelog-action@v1.3
         with:
           args: init --output CHANGELOG.md --compare-url https://example.com/abcdef...HEAD
-      - name: Create an initial commit
+      - name: Commit the CHANGELOG
         run: |
           git commit -am "Add a changelog"
-      - name: Run changelog release
+      - name: Create a release in the CHANGELOG
         uses: cucumber-actions/changelog-action@v1.3
         with:
           args: release --output CHANGELOG.md 1.0.0
-      - name: Commit release
+      - name: Commit the release
         run: |
           git commit -am "Release v1.0.0"
       - name: Create release branch
         run: |
           git checkout HEAD^
           git checkout -b release/test/v1.0.0
-          git merge develop
+          git merge --ff-only develop 
           git push --force --set-upstream origin release/test/v1.0.0
       - name: Attempt to create Release
         uses: ./
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          tag-prefix: 'test/'
       - name: Assert result
         run: |
-          release=$(gh release list | grep test/v1.0.0)
+          release=$(gh release list | grep v1.0.0)
           [ "$release" ]
           gh release delete $release
-          git push origin :refs/release/test/v1.0.0
+          git push origin :refs/heads/release/test/v1.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Attempt to create Release
         uses: ./
         with:
-          github-token: ${{ GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           tag-prefix: 'test/'
       - name: Assert result
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,16 +25,16 @@ jobs:
       - name: Create a release in the CHANGELOG
         uses: cucumber-actions/changelog-action@v1.3
         with:
-          args: release --output CHANGELOG.md 1.0.0
+          args: release --output CHANGELOG.md T.E.S.T
       - name: Commit the release
         run: |
-          git commit -am "Release v1.0.0"
+          git commit -am "Release vT.E.S.T"
       - name: Create release branch
         run: |
           git checkout HEAD^
-          git checkout -b release/test/v1.0.0
+          git checkout -b release/test
           git merge --ff-only develop 
-          git push --force --set-upstream origin release/test/v1.0.0
+          git push --set-upstream origin release/test
       - name: Attempt to create Release
         uses: ./
         with:
@@ -43,7 +43,17 @@ jobs:
         env: 
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          release=$(gh release list | grep v1.0.0 | cut -f1)
+          # Assert release exists
+          release=$(gh release list | grep vtest | cut -f1)
           [ "$release" ]
+
+          # Assert tag points to the head of `develop` branch
+          expected=$(git rev-parse develop)
+          actual=$(git rev-parse vT.E.S.T)
+          [ "$expected" = "$actual" ]
+
+          # Clean up
           gh release delete $release
-          git push origin :refs/heads/release/test/v1.0.0
+          git push origin :refs/heads/develop
+          git push origin :refs/heads/release/test
+          git push origin :refs/tags/vT.E.S.T

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
         run: |
           git config --global user.email "github-actions@example.com"
           git config --global user.name "GitHub Actions"
-          git checkout -b develop --orphan
+          git checkout --orphan develop
       - run: touch CHANGELOG.md
       - name: Create a simple changelog file
         uses: cucumber-actions/changelog-action@v1.3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,16 +39,16 @@ jobs:
         uses: ./
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Assert release exists
+      - name: Assertions / cleanup
         env: 
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Assert release exists
+          # Assert that the release was created
           expected_name="vT.E.S.T"
           release=$(gh release list | grep $expected_name | cut -f1)
           [ "$release" ] || (echo "No release created named $expected_name" && exit 1)
 
-          # Assert tag points to the head of `develop` branch
+          # Assert that a tag for the release points to the head of `develop` branch
           expected=$(git rev-parse develop)
           actual=$(git rev-parse vT.E.S.T)
           [ "$expected" = "$actual" ] || (echo "Commit $expected not tagged as expected" && exit 1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0] - 2021-09-20
 ### Added
-- Initial sketch
+- Make a Release tagging the HEAD of the current branch
 
-[Unreleased]: https://github.com/cucumber-actions/versions/v0.0.0...HEAD
+[Unreleased]: https://github.com/cucumber-actions/versions/1.0.0...HEAD
+[1.0.0]: https://github.com/cucumber-actions/versions/v0.0.0...1.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+Everyone contributing to this repo is expected to abide by the [Cucumber Community Code of Conduct](https://cucumber.io/conduct).
+
+## Making a release
+
+There are two parts to making a release. First, prepare the release, then make the release.
+
+### Preparing a release
+
+Anyone with commit rights to `main` can prepare a release.
+
+To make a release of this action, you can use the [`changelog`](https://github.com/rcmachado/changelog) tool.
+
+First, make sure your changes are detailed in the `Unreleased` section of the [CHANGELOG](./CHANGELOG.md) file.
+
+Then, use [semver](https://semver.org/) to pick a version for the next release.
+
+    read $next_release
+
+Modify the changelog:
+
+    changelog release $next_release
+
+Commit and push
+
+     git add .
+     git commit -m "Release $next_release"
+
+The [`pre-release` workflow](https://github.com/cucumber-actions/create-release/actions/workflows/pre-release.yaml) will pick up your changes and create a pull request for the release.
+
+### Making a release
+
+Only people with rights to push to the `release/*` branch pattern can make releases.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Then, use [semver](https://semver.org/) to pick a version for the next release.
 
 Modify the changelog:
 
-    changelog release $next_release
+    changelog release $next_release -o CHANGELOG.md
 
 Commit and push
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
 FROM mattwynne/changelog:latest
+CMD apt install curl
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,3 @@
 FROM mattwynne/changelog:latest
-RUN apk add --no-cache wget
-RUN wget https://github.com/cli/cli/releases/download/v1.14.0/gh_1.14.0_linux_386.tar.gz -O ghcli.tar.gz
-RUN tar --strip-components=1 -xf ghcli.tar.gz
-ENV PATH="${PATH}:bin/"
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM mattwynne/changelog:latest
-CMD apt install curl
+CMD sudo apt-get install curl
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM mattwynne/changelog:latest
-RUN apt-get update && apt-get install wget
+RUN apk add --no-cache wget
 RUN wget https://github.com/cli/cli/releases/download/v1.14.0/gh_1.14.0_linux_386.tar.gz -O ghcli.tar.gz
 RUN tar --strip-components=1 -xf ghcli.tar.gz
 ENV PATH="${PATH}:bin/"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM mattwynne/changelog:latest
-CMD sudo apt-get install curl
+CMD apk add curl
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM mattwynne/changelog:latest
-RUN apt-get update && apt-get install curl
-RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg
-RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-RUN sudo apt update && sudo apt install gh
+RUN apt-get update && apt-get install wget
+RUN wget https://github.com/cli/cli/releases/download/v1.14.0/gh_1.14.0_linux_386.tar.gz -O ghcli.tar.gz
+RUN tar --strip-components=1 -xf ghcli.tar.gz
+ENV PATH="${PATH}:bin/"
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM mattwynne/changelog:latest
-COPY entrypoint.sh /entrypoint.sh
+RUN apt-get update && apt-get install curl
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg
 RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
 RUN sudo apt update && sudo apt install gh
+COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,6 @@
 FROM mattwynne/changelog:latest
 COPY entrypoint.sh /entrypoint.sh
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg
+RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+RUN sudo apt update && sudo apt install gh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM mattwynne/changelog:latest
-CMD apk add curl
+RUN apk add curl
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 This action was developed by the Cucumber team to use as part of our automated release process.
 
-It is designed to run on push to a `release/*` branch, to create a GitHub Release containing the release notes from the CHANGELOG, and a git tag.
+It is designed to run on push to a `release/*` branch, to create a GitHub Release containing the release notes from the CHANGELOG, and tag the commit being released.
 
 It uses the `changelog` tool to read the version number and notes for the latest release, then calls the GitHub API to create a Release on the GitHub repo.
+
+It creates a git tag of the form `vX.Y.Z` and looks in the root directory for the `CHANGELOG.md` file.
 
 ## Inputs
 
@@ -12,7 +14,26 @@ The action requires a token to call the GitHub API to create the Release:
 
 * `github-token`
 
-By default, the action creates a git tag of the form `vX.Y.Z` and looks in the root directory for the `CHANGELOG.md` file. You can customize this (e.g. for a monorepo) by using these inputs:
+The token needs 'write' permissions on the repo.
 
-* `tag-prefix` - A prefix to use when creating a git tag, e.g. `cucumber-expressions/`
-* `changelog-directory` - Path within the repo to look for the `CHANGELOG.md` file
+## Example
+
+````yaml
+name: Release
+
+on:
+  push:
+    branches: [release/*]
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    environment: Release
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v2
+      - uses: cucumber-actions/create-release
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+````

--- a/action.yml
+++ b/action.yml
@@ -7,18 +7,8 @@ inputs:
     description: "Github token to use when calling GitHub API to create Release"
     default: ""
 
-  tag-prefix:
-    description: "A prefix to use when searching for tags, e.g. `cucumber-expressions/`"
-    default: ""
-
-  changelog-directory:
-    description: "Path within the repo to look for the CHANGELOG.md file"
-    default: "."
-
 runs:
   using: "docker"
   image: Dockerfile
   args:
     - ${{ inputs.github-token }}
-    - ${{ inputs.tag-prefix }}
-    - ${{ inputs.changelog-directory }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,10 +13,18 @@ body=$(changelog show "$next_version_heading")
 sha=$GITHUB_SHA
 name=v$next_version
 tag=v$next_version
+cat <<EOT >> data.json
+{
+  "tag_name": "$tag",
+  "target_commitish": "$sha",
+  "body":"$body",
+  "name":"$name"
+}
+EOT
 echo $data
 curl \
   -X POST \
   -H "Authorization: token $1" \
   -H "Accept: application/vnd.github.v3+json" \
   https://api.github.com/repos/$GITHUB_REPOSITORY/releases \
-  -d '{"tag_name":"'"$tag"'", "target_commitish":"'"$sha"'", "body":"'"$body"'", "name":"'"$name"'"}'
+  -d @data.json

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,7 +11,6 @@ body=$(changelog show "$next_version_heading")
 
 # Create GitHub Release
 sha=$GITHUB_SHA
-body=$(cat $RUNNER_TEMP/notes)
 name=v$next_version
 tag=v$next_version
 curl \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,10 +4,10 @@
 next_version_heading=$(changelog latest --filename CHANGELOG.md)
 next_version=${next_version_heading/v}
 next_version=$([[ "$next_version" == There* ]] && (echo $next_version && exit 1) || echo $next_version)
+echo "Next version: '$next_version'"
 
 # Get release notes from CHANGELOG
-echo "Next version: '$next_version_heading'"
-changelog show "$next_version_heading" --filename CHANGELOG.md --output $RUNNER_TEMP/notes
+body=$(changelog show "$next_version_heading" --filename CHANGELOG.md --output)
 
 # Create GitHub Release
 sha=$GITHUB_SHA

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,4 +21,4 @@ curl \
   -X POST \
   -H "Accept: application/vnd.github.v3+json" \
   https://api.github.com/repos/$GITHUB_REPOSITORY/releases \
-  -d $data
+  -d "'"$data"'"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,9 +13,12 @@ body=$(changelog show "$next_version_heading")
 sha=$GITHUB_SHA
 name=v$next_version
 tag=v$next_version
+data='{"tag_name":"$tag", "target_commitish":"$sha", "body":"$body", "name":"$name"}'
+echo $data
 curl \
+  -v \
   -H "Authorization: token $1" \
   -X POST \
   -H "Accept: application/vnd.github.v3+json" \
   https://api.github.com/repos/$GITHUB_REPOSITORY/releases \
-  -d '{ "tag_name":"$tag", "target_commitish":"$sha", "body":"$body", "name":"$name"}'
+  -d $data

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,7 +6,8 @@ next_version=${next_version_heading/v}
 next_version=$([[ "$next_version" == There* ]] && (echo $next_version && exit 1) || echo $next_version)
 
 # Get release notes from CHANGELOG
-changelog show $next_version_heading --filename CHANGELOG.md --output $RUNNER_TEMP/notes
+echo "Next version: '$next_version_heading'"
+changelog show "$next_version_heading" --filename CHANGELOG.md --output $RUNNER_TEMP/notes
 
 # Create GitHub Release
 sha=$GITHUB_SHA

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Read next version from CHANGLOG
-next_version_heading=$(changelog latest --filename $3/CHANGELOG.md)
+next_version_heading=$(changelog latest --filename CHANGELOG.md)
 next_version=${next_version_heading/v}
 next_version=$([[ "$next_version" == There* ]] && (echo $next_version && exit 1) || echo $next_version)
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,7 +7,7 @@ next_version=$([[ "$next_version" == There* ]] && (echo $next_version && exit 1)
 echo "Next version: '$next_version'"
 
 # Get release notes from CHANGELOG
-body=$(changelog show "$next_version_heading" --filename CHANGELOG.md --output)
+body=$(changelog show "$next_version_heading")
 
 # Create GitHub Release
 sha=$GITHUB_SHA

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,7 +6,7 @@ next_version=${next_version_heading/v}
 next_version=$([[ "$next_version" == There* ]] && (echo $next_version && exit 1) || echo $next_version)
 
 # Get release notes from CHANGELOG
-changelog show --filename CHANGELOG.md --output $RUNNER_TEMP/notes
+changelog show $next_version_heading --filename CHANGELOG.md --output $RUNNER_TEMP/notes
 
 # Create GitHub Release
 sha=$GITHUB_SHA

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,7 +10,8 @@ echo "Next version: '$next_version'"
 body=$(changelog show "$next_version_heading")
 
 # Create GitHub Release
-sha=$GITHUB_SHA
+sha=$(git rev-parse HEAD)
+echo "Release sha: $sha"
 name=v$next_version
 tag=v$next_version
 cat <<EOT >> data.json

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,7 +13,7 @@ body=$(changelog show "$next_version_heading")
 sha=$GITHUB_SHA
 name=v$next_version
 tag=v$next_version
-data='{"tag_name":"$tag", "target_commitish":"$sha", "body":"$body", "name":"$name"}'
+data='{"tag_name":"'"$tag"'", "target_commitish":"'"$sha"'", "body":"'"$body"'", "name":"'"$name"'"}'
 echo $data
 curl \
   -v \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,9 +16,8 @@ tag=v$next_version
 data='{"tag_name":"'"$tag"'", "target_commitish":"'"$sha"'", "body":"'"$body"'", "name":"'"$name"'"}'
 echo $data
 curl \
-  -v \
-  -H "Authorization: token $1" \
   -X POST \
+  -H "Authorization: token $1" \
   -H "Accept: application/vnd.github.v3+json" \
   https://api.github.com/repos/$GITHUB_REPOSITORY/releases \
   -d "'"$data"'"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,11 +13,10 @@ body=$(changelog show "$next_version_heading")
 sha=$GITHUB_SHA
 name=v$next_version
 tag=v$next_version
-data='{"tag_name":"'"$tag"'", "target_commitish":"'"$sha"'", "body":"'"$body"'", "name":"'"$name"'"}'
 echo $data
 curl \
   -X POST \
   -H "Authorization: token $1" \
   -H "Accept: application/vnd.github.v3+json" \
   https://api.github.com/repos/$GITHUB_REPOSITORY/releases \
-  -d "'"$data"'"
+  -d '{"tag_name":"'"$tag"'", "target_commitish":"'"$sha"'", "body":"'"$body"'", "name":"'"$name"'"}'


### PR DESCRIPTION
- Fix workflow syntax
- Fix branch create in test
- Caps
- Name test workflow
- Help with push
- Try to install `gh`
- Force push
- Install curl
- Try downloading binary for gh
- apk not apt
- Update to use no `gh` commands
- Show next version
- No need to install gh anymore
- Debug
- Install curl
- Fix path to CHANGELOG
- Read body directly
- args
- Whoops
- Try to install curl better
- apk?
- RUN not CMD
- Authenticate assertions step in test
- Debug
- Escaping
- More escaping
- Tweaks to curl command
- Inline data
- Put data in a file
- Read gh release list output properly
- Tweak branch / tag names and add another assetion
- Better assertion messages
- precedence
- Comments
- Make test more resilient
- Make sure tags are fetched before assertion
- Factor out test cleanup
- Split test cleanup into two steps
- Remove git commands from first step
- We don't mind if these commands succeed or not
- Make cleanup more resilient
- Skip manual confirm of release delete
- Try something else
- debug
- Check gh auth
- Debug
- pare down what we do in that failling step
- Debug
- More debug
- Fix test cleanup
- Add notes on making releases
- Fix changelog command
- Release v1.0.0
- Trigger pre-release
- Try fetching more depth
